### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through a stack trace

### DIFF
--- a/supabase/functions/generate-content/index.ts
+++ b/supabase/functions/generate-content/index.ts
@@ -307,10 +307,10 @@ Make it actionable, engaging, and tailored to the specified audience and tone.`;
 
   } catch (error) {
     console.error('Error in generate-content function:', error);
+    console.error('Error in generate-content function:', error.stack);
     return new Response(
       JSON.stringify({ 
-        error: error.message || 'An unexpected error occurred',
-        details: error.stack
+        error: 'An unexpected error occurred. Please try again later.'
       }),
       { 
         status: 500,


### PR DESCRIPTION
Potential fix for [https://github.com/Jensinjames/launch-click-alpha/security/code-scanning/3](https://github.com/Jensinjames/launch-click-alpha/security/code-scanning/3)

To fix this issue, the stack trace (`error.stack`) should be removed from the HTTP response sent to the client. Instead, a generic error message should be sent to the client, while the detailed stack trace should be logged on the server for debugging purposes.

Steps to implement:
1. Modify the `catch` block to exclude `error.stack` from the response body.
2. Add a generic error message in the response body to inform the user of the failure without exposing sensitive information.
3. Ensure the stack trace is logged on the server using `console.error` for debugging purposes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to provide a more user-friendly and secure error message when an unexpected issue occurs. Detailed error information is no longer shown to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->